### PR TITLE
feat: L자 컷어웨이 돌하우스 뷰 구현

### DIFF
--- a/apps/game/eslint.config.js
+++ b/apps/game/eslint.config.js
@@ -3,10 +3,28 @@ import { config } from '@repo/eslint-config/react';
 export default [
   ...config,
   {
+    ignores: ['dist/**'],
+  },
+  {
     rules: {
       'react/no-unknown-property': [
         'error',
-        { ignore: ['rotation', 'position', 'args', 'intensity'] },
+        {
+          ignore: [
+            // React Three Fiber 속성들
+            'rotation',
+            'position',
+            'args',
+            'intensity',
+            'castShadow',
+            'shadow-mapSize',
+            'transparent',
+            'opacity',
+            'side',
+            'metalness',
+            'roughness',
+          ],
+        },
       ],
     },
   },

--- a/apps/game/src/app/components/room/index.tsx
+++ b/apps/game/src/app/components/room/index.tsx
@@ -4,6 +4,9 @@ import { FurnitureView } from '../furniture/furniture.view';
 import { Floor } from './floor.view';
 import { Wall } from './wall.view';
 
+/** L자 컷어웨이 뷰에서 보이는 벽 (북쪽 + 서쪽) */
+const VISIBLE_WALL_SIDES = ['north', 'west'];
+
 interface RoomProps {
   room: RoomModel;
 }
@@ -11,21 +14,21 @@ interface RoomProps {
 export function Room({ room }: RoomProps): JSX.Element {
   const { width, depth, height, walls, furnitures } = room;
 
+  // L자 컷어웨이: 북쪽과 서쪽 벽만 렌더링
+  const visibleWalls = walls.filter((wall) => VISIBLE_WALL_SIDES.includes(wall.side));
+
   return (
     <group>
       <Floor floor={{ width, depth }} />
-      {walls.map((wall) => (
-        <Wall
-          key={wall.id}
-          wall={wall}
-          height={height}
-        />
+
+      {/* 뒷벽 (L자형) */}
+      {visibleWalls.map((wall) => (
+        <Wall key={wall.id} wall={wall} height={height} />
       ))}
+
+      {/* 가구 */}
       {furnitures.map((furniture) => (
-        <FurnitureView
-          key={furniture.id}
-          furniture={furniture}
-        />
+        <FurnitureView key={furniture.id} furniture={furniture} />
       ))}
     </group>
   );

--- a/apps/game/src/app/components/room/wall.view.tsx
+++ b/apps/game/src/app/components/room/wall.view.tsx
@@ -141,7 +141,7 @@ export function Wall({ wall, height }: WallProps): JSX.Element {
             position={[segCenterX, segCenterY, 0]}
           >
             <boxGeometry args={[segWidth, segHeight, thickness]} />
-            <meshStandardMaterial color="#ffffff" />
+            <meshStandardMaterial color="#f5f5f0" />
           </mesh>
         );
       })}

--- a/apps/game/src/app/index.tsx
+++ b/apps/game/src/app/index.tsx
@@ -5,19 +5,52 @@ import { Room } from './components/room';
 import { sampleRoom } from '@/data/sample-room.data';
 
 export default function App(): JSX.Element {
+  // 방 중심점 계산
+  const roomCenterX = sampleRoom.width / 2;
+  const roomCenterZ = sampleRoom.depth / 2;
+  const roomCenterY = sampleRoom.height / 3;
+
   return (
     <Canvas
-      camera={{ position: [5, 5, 5], fov: 50 }}
-      style={{ width: '100vw', height: '100vh' }}
+      orthographic
+      camera={{
+        // 코너 뷰: 오른쪽 앞에서 왼쪽 뒤 코너를 바라봄
+        position: [roomCenterX + 8, 6, roomCenterZ + 8],
+        zoom: 90,
+        near: 0.1,
+        far: 100,
+      }}
+      style={{ width: '100vw', height: '100vh', background: '#2a2a3e' }}
     >
-      <ambientLight intensity={0.5} />
+      {/* 환경광: 부드러운 전체 조명 */}
+      <ambientLight intensity={0.4} />
+
+      {/* 메인 조명: 창문 방향에서 들어오는 빛 */}
       <directionalLight
-        position={[10, 10, 5]}
-        intensity={1}
+        position={[-5, 8, 3]}
+        intensity={1.2}
+        castShadow
+        shadow-mapSize={[1024, 1024]}
       />
+
+      {/* 보조 조명: 반대편에서 부드럽게 */}
+      <directionalLight
+        position={[5, 3, 5]}
+        intensity={0.3}
+      />
+
       <Room room={sampleRoom} />
-      <OrbitControls />
-      <gridHelper args={[4, 4]} />
+
+      <OrbitControls
+        target={[roomCenterX, roomCenterY, roomCenterZ]}
+        enableRotate={true}
+        enableZoom={true}
+        enablePan={false}
+        minPolarAngle={Math.PI / 5}
+        maxPolarAngle={Math.PI / 3}
+        minAzimuthAngle={Math.PI / 6}
+        maxAzimuthAngle={Math.PI / 2.5}
+      />
     </Canvas>
   );
 }

--- a/apps/game/src/data/sample-room.data.ts
+++ b/apps/game/src/data/sample-room.data.ts
@@ -13,22 +13,25 @@ const STANDARD_SILL_HEIGHT_M = 0.9;
 const STANDARD_DOOR_WIDTH_M = 0.9;
 
 function createRectangularWalls(width: number, depth: number): Wall[] {
-  const southWindow: Window = {
-    id: 'south-window-1',
-    position: 0.5,
-    width: 1.8,
-    height: 1.2,
-    sillHeight: STANDARD_SILL_HEIGHT_M,
-  };
-
+  // 문: 북쪽 벽 (z=0) - 왼쪽에 배치
   const northDoor: Door = {
     id: 'north-door-1',
-    position: 0.5,
+    position: 0.25,
     width: STANDARD_DOOR_WIDTH_M,
     height: 2.1,
   };
 
+  // 창문: 서쪽 벽 (x=0) - L자 코너 뷰를 위해 인접한 벽에 배치
+  const westWindow: Window = {
+    id: 'west-window-1',
+    position: 0.6,
+    width: 1.5,
+    height: 1.2,
+    sillHeight: STANDARD_SILL_HEIGHT_M,
+  };
+
   return [
+    // 뒷벽 (카메라에서 보이는 벽들)
     {
       id: 'north',
       side: 'north',
@@ -38,25 +41,26 @@ function createRectangularWalls(width: number, depth: number): Wall[] {
       doors: [northDoor],
     },
     {
+      id: 'west',
+      side: 'west',
+      start: { x: 0, z: 0 },
+      end: { x: 0, z: depth },
+      thickness: WALL_THICKNESS,
+      windows: [westWindow],
+    },
+    // 앞벽 (컷어웨이로 제거될 벽들)
+    {
       id: 'south',
       side: 'south',
       start: { x: 0, z: depth },
       end: { x: width, z: depth },
       thickness: WALL_THICKNESS,
-      windows: [southWindow],
     },
     {
       id: 'east',
       side: 'east',
       start: { x: width, z: 0 },
       end: { x: width, z: depth },
-      thickness: WALL_THICKNESS,
-    },
-    {
-      id: 'west',
-      side: 'west',
-      start: { x: 0, z: 0 },
-      end: { x: 0, z: depth },
       thickness: WALL_THICKNESS,
     },
   ];


### PR DESCRIPTION
## Summary

<img width="2209" height="1072" alt="스크린샷 2025-12-22 오후 10 29 34" src="https://github.com/user-attachments/assets/4e446cb5-72e4-49a9-a8ba-9c9fadae0f58" />

- Orthographic 카메라로 변경하여 아이소메트릭 뷰 구현
- L자 컷어웨이 뷰: 북쪽(문) + 서쪽(창문) 벽만 렌더링
- 카메라 회전 제한 (수평만, 제한된 각도)
- 조명 개선 (창문 방향 메인 조명 + 보조 조명)

## Changes
- `apps/game/src/app/index.tsx`: Orthographic 카메라, OrbitControls 제한, 조명 설정
- `apps/game/src/app/components/room/index.tsx`: 2면만 렌더링
- `apps/game/src/app/components/room/wall.view.tsx`: 벽 색상 변경
- `apps/game/src/data/sample-room.data.ts`: 창문을 서쪽 벽으로 이동
- `apps/game/eslint.config.js`: dist 제외, R3F 속성 추가

## Test plan
- [x] `pnpm dev`로 돌하우스 뷰 확인
- [x] 카메라 회전/줌 테스트
- [x] 문/창문이 올바르게 렌더링되는지 확인